### PR TITLE
Draft: Initial support for OpenShift in Compliance and AC

### DIFF
--- a/checkpoint/cloudguard/Chart.yaml
+++ b/checkpoint/cloudguard/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 appVersion: 2.4.0
-version: 2.4.0
 description: A Helm chart for Check Point CloudGuard Workload Security
-name: cloudguard
+home: https://portal.checkpoint.com
+icon: https://www.checkpoint.com/wp-content/uploads/icon-cloudguard-nav.png
 keywords:
 - check point
 - cloudguard
@@ -15,5 +15,5 @@ keywords:
 - threat intelligence
 - admission control
 - runtime protection
-home: https://portal.checkpoint.com
-icon: https://www.checkpoint.com/wp-content/uploads/icon-cloudguard-nav.png
+name: cloudguard
+version: 2.4.0

--- a/checkpoint/cloudguard/templates/_helpers.tpl
+++ b/checkpoint/cloudguard/templates/_helpers.tpl
@@ -72,7 +72,7 @@ helm.sh/chart: {{ printf "%s-%s" .Chart.name .Chart.version | replace "+" "_" | 
 {{- /* Pod annotations commonly used in agents */ -}}
 {{- define "common.pod.annotations" -}}
 agentVersion: {{ .agentConfig.tag }}
-seccomp.security.alpha.kubernetes.io/pod: {{ .Values.podAnnotations.seccomp }}
+# seccomp.security.alpha.kubernetes.io/pod: {{ .Values.podAnnotations.seccomp }}
 {{- if .Values.podAnnotations.apparmor }}
 container.apparmor.security.beta.kubernetes.io/{{ template "agent.resource.name" . }}:
 {{ toYaml .Values.podAnnotations.apparmor | indent 2 }}

--- a/checkpoint/cloudguard/templates/admission/enforcer/deployment.yaml
+++ b/checkpoint/cloudguard/templates/admission/enforcer/deployment.yaml
@@ -24,8 +24,8 @@ spec:
 {{ include "common.labels" $config | indent 8 }}
     spec:
 {{ include "common.pod.properties" $config | indent 6 }}
-      securityContext:
-        runAsUser: 1000
+#      securityContext:
+#        runAsUser: 1000
       containers:
       # gsl (note: should be first to simplify Pod startup)
       - {{ $containerConfig := merge $config (dict "containerName" "gsl") -}}
@@ -84,7 +84,7 @@ spec:
         imagePullPolicy: {{ $config.Values.imagePullPolicy }}
         securityContext:
           allowPrivilegeEscalation: false
-          runAsUser: 1000
+#          runAsUser: 1000
         env:
 {{ include "fluentbit.env" $config | indent 8 }}
         - name: CP_KUBERNETES_ADMISSION_CONTROLLER_ALERTS_URI

--- a/checkpoint/cloudguard/templates/admission/policy/deployment.yaml
+++ b/checkpoint/cloudguard/templates/admission/policy/deployment.yaml
@@ -22,8 +22,8 @@ spec:
 {{ include "common.labels" $config | indent 8 }}
     spec:
 {{ include "common.pod.properties" $config | indent 6 }}
-      securityContext:
-        runAsUser: 1000
+#      securityContext:
+#        runAsUser: 1000
       containers:
       # Main container
       - name: {{ $config.agentName }}
@@ -49,7 +49,7 @@ spec:
         imagePullPolicy: {{ $config.Values.imagePullPolicy }}
         securityContext:
           allowPrivilegeEscalation: false
-          runAsUser: 1000
+#          runAsUser: 1000
         env:
 {{ include "fluentbit.env" $config | indent 8 }}
         - name: CP_KUBERNETES_METRIC_URI

--- a/checkpoint/cloudguard/templates/imagescan/daemon/_helpers.tpl
+++ b/checkpoint/cloudguard/templates/imagescan/daemon/_helpers.tpl
@@ -4,7 +4,9 @@
 {{- $_ := set $config "agentName" "daemon" }}
 {{- $_ := set $config "featureConfig" $config.Values.addons.imageScan }}
 {{- $_ := set $config "agentConfig" $config.Values.addons.imageScan.daemon }}
+{{- if $config.featureConfig.enabled }}
 {{- $_ := set $config "containerRuntime" (include "get.container.runtime" .) }}
+{{- end }}
 {{- $config | toYaml -}}
 {{- end -}}
 

--- a/checkpoint/cloudguard/templates/imagescan/engine/_helpers.tpl
+++ b/checkpoint/cloudguard/templates/imagescan/engine/_helpers.tpl
@@ -4,7 +4,9 @@
 {{- $_ := set $config "agentName" "engine" }}
 {{- $_ := set $config "featureConfig" $config.Values.addons.imageScan }}
 {{- $_ := set $config "agentConfig" $config.Values.addons.imageScan.engine }}
+{{- if $config.featureConfig.enabled }}
 {{- $_ := set $config "containerRuntime" (include "get.container.runtime" .) }}
+{{- end }}
 {{- $config | toYaml -}}
 {{- end -}}
 

--- a/checkpoint/cloudguard/templates/inventory/agent/deployment.yaml
+++ b/checkpoint/cloudguard/templates/inventory/agent/deployment.yaml
@@ -21,8 +21,8 @@ spec:
 {{ include "common.labels" $config | indent 8 }}
     spec:
 {{ include "common.pod.properties" $config | indent 6 }}
-      securityContext:
-        runAsUser: {{ include "cloudguard.nonroot.user" $config }}
+#      securityContext:
+#        runAsUser: {{ include "cloudguard.nonroot.user" $config }}
       containers:
       # Main container
       - name: {{ $config.agentName }}

--- a/checkpoint/cloudguard/templates/runtime/daemon/_helpers.tpl
+++ b/checkpoint/cloudguard/templates/runtime/daemon/_helpers.tpl
@@ -4,6 +4,8 @@
 {{- $_ := set $config "agentName" "daemon" }}
 {{- $_ := set $config "featureConfig" $config.Values.addons.runtimeProtection }}
 {{- $_ := set $config "agentConfig" $config.Values.addons.runtimeProtection.daemon }}
+{{- if $config.featureConfig.enabled }}
 {{- $_ := set $config "containerRuntime" (include "get.container.runtime" .) }}
+{{- end }}
 {{- $config | toYaml -}}
 {{- end -}}


### PR DESCRIPTION
- remove RunAsUser, let OpenShift manage UIDs
- remove seccomp, let OpenShift manage (via SCCs)
- do not try detecting container runtime if runtime/imagescan feature is not enabled (to avoid failure due to cri-o)